### PR TITLE
Update posts to avoid using `Invariant`

### DIFF
--- a/_posts/2022-06-01-using-the-kani-rust-verifier-on-a-rust-standard-library-cve.md
+++ b/_posts/2022-06-01-using-the-kani-rust-verifier-on-a-rust-standard-library-cve.md
@@ -490,7 +490,7 @@ In our discussion of the CVE, we introduced the idea of a [*representation invar
 A representation invariant tells us when a queue is *well-formed*.
 This is the case if the buffer capacity is a (nonzero) power of two and if the `head` and `tail ` index within the buffer.
 [Recall that these properties are precisely the ones checked using `debug_assert` in `handle_capacity_increase`.]
-In Kani, we can write a method `is_valid` to express that a type `T` fulfills its type invariant:
+In Kani, we can write a method `is_valid` to express that a type `T` is well-formed:
 
 ```rust
 impl AbstractVecDeque {
@@ -501,7 +501,7 @@ impl AbstractVecDeque {
 ```
 
 Then, we can use this method to implement `kani::any::<T>()`, required by the `Arbitrary` trait from Kani,
-to generate symbolic values of type `T` that respect its type invariant as follows:
+to generate well-formed symbolic values of type `T` as follows:
 
 ```rust
 impl kani::Arbitrary for AbstractVecDeque {

--- a/_posts/2022-07-13-using-the-kani-rust-verifier-on-a-firecracker-example.md
+++ b/_posts/2022-07-13-using-the-kani-rust-verifier-on-a-firecracker-example.md
@@ -203,7 +203,7 @@ Let's start with a simple one from the virtio specification.
 >
 > The driver MUST place any device-writable descriptor elements after any device-readable descriptor elements.
 >
-> Source: <https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-280004>
+> [Source: Virtual I/O Device v1.1](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-280004)
 
 This is a requirement on the driver under the control of the guest.
 However, Firecracker cannot trust that this is the case: the requirement has to be validated.
@@ -305,18 +305,18 @@ This is an enum that includes guest memory errors such as requesting an invalid 
 The intention of our mock is to enable Kani to explore the behavior of a caller of `read_obj` (like `parse`) under any of these possibilities.
 
 ```rust
-    fn read_obj<T>(&self, addr: GuestAddress) -> Result<T, Error>
-    where
-        T: ByteValued + kani::Invariant + ReadObjChecks<T>,
-    {
-        if kani::any() {
-            let val = kani::any::<T>();
-            T::check_on_read_val(&self, &val);
-            Ok(val)
-        } else {
-            Err(kani::any::<Error>())
-        }
+fn read_obj<T>(&self, addr: GuestAddress) -> Result<T, Error>
+where
+    T: ByteValued + kani::Arbitrary + ReadObjChecks<T>,
+{
+    if kani::any() {
+        let val = kani::any::<T>();
+        T::check_on_read_val(&self, &val);
+        Ok(val)
+    } else {
+        Err(kani::any::<Error>())
     }
+}
 ```
 
 Now let's address the `ReadObjChecks` trait bound that we added, which allows us to call `T::check_on_read_val` where we pass in the generated symbolic value.
@@ -402,9 +402,9 @@ Look out for a follow up post where we'll use Kani on an example from [Tokio](ht
 
 ## Further Reading
 
-  - Firecracker: <https://firecracker-microvm.github.io/>
-  - Firecracker NSDI 2020 paper: <https://www.usenix.org/conference/nsdi20/presentation/agache>
-  - Firecracker's design doc: <https://github.com/firecracker-microvm/firecracker/blob/main/docs/design.md>
+  - [Firecracker project](https://firecracker-microvm.github.io/)
+  - [Firecracker NSDI 2020 paper](https://www.usenix.org/conference/nsdi20/presentation/agache)
+  - [Firecracker's design doc](https://github.com/firecracker-microvm/firecracker/blob/main/docs/design.md)
   - [Code and instructions for reproducing the results in this post](https://github.com/model-checking/kani/tree/main/tests/cargo-kani/firecracker-block-example)
 
 ## Footnotes


### PR DESCRIPTION
This PR updates the "standard library" and "firecracker" posts to avoid discussing the `Invariant` trait, which was deprecated in Kani and will soon be removed.

The examples for these posts have been updated already in https://github.com/model-checking/kani/pull/1523. The replacement is quite simple: Define a `is_valid` method to express the invariant, and assume it in `any` definitions to generate values that respect the invariant. This is likely not worth mentioning, but we can still add a footnote to explain we updated the post after the `Invariant` trait deprecation.

Also, does some minor presentation improvements (links, code block).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
