### PR TITLE
Correct Kani invokation in Tokio post

### DIFF
--- a/_posts/2022-08-17-using-the-kani-rust-verifier-on-tokio-bytes.md
+++ b/_posts/2022-08-17-using-the-kani-rust-verifier-on-tokio-bytes.md
@@ -155,7 +155,7 @@ As you'd expect, this has no problems and confirms the behavior explained above.
 In this particular case, there is no advantage to using Kani rather than running the test, but it is nice to show Kani handling code that internally uses unsafe Rust.
 
 ```bash
-$ cargo kani --harness test_kind_representation
+$ cargo kani --harness test_kind_representation_change
 # --snip--
 VERIFICATION:- SUCCESSFUL
 ```


### PR DESCRIPTION
*Description of changes:* Corrects the `cargo kani` invokation in the Tokio post

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
