### PR TITLE
Fix mistake in Firecracker post

### DIFF
--- a/_posts/2022-07-13-using-the-kani-rust-verifier-on-a-firecracker-example.md
+++ b/_posts/2022-07-13-using-the-kani-rust-verifier-on-a-firecracker-example.md
@@ -376,7 +376,7 @@ mod verification {
 ```
 
 Passing the harness to Kani results in `VERIFICATION:- SUCCESSFUL` in a few seconds.
-As sanity check, if we insert an issue such as forgetting a validity check to ensure the third buffer is read-only, then Kani reports an error (since in this case it is possible to fail virtio requirement 2.6.4.2 but return a valid `Request`).
+As sanity check, if we insert an issue such as forgetting a validity check to ensure the third buffer is write-only, then Kani reports an error (since in this case it is possible to fail virtio requirement 2.6.4.2 but return a valid `Request`).
 Our example is available in Kani's test directory with instructions on reproducing these results.
 
 But what does this result mean?


### PR DESCRIPTION
*Issue #, if available:* https://github.com/model-checking/kani/issues/1976

*Description of changes:* Fixes a mistake in the Firecracker blog post, as discussed in https://github.com/model-checking/kani/issues/1976

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
