### PR TITLE
Use fixed hash in link to avoid bitrot

### DIFF
--- a/_posts/2022-12-21-easily-verify-your-rust-in-ci-with-kani.md
+++ b/_posts/2022-12-21-easily-verify-your-rust-in-ci-with-kani.md
@@ -47,7 +47,7 @@ jobs:
 ```
 
 For more advanced use cases, we provide facilities to override the working directory, as well as to configure the Kani command itself.
-For example, the [s2n-quic](https://github.com/aws/s2n-quic) project uses [the following CI configuration](https://github.com/aws/s2n-quic/blob/main/.github/workflows/ci.yml#L613), which overrides the working directory, and enables the `--tests` option of `cargo kani`.
+For example, the [s2n-quic](https://github.com/aws/s2n-quic) project uses [the following CI configuration](https://github.com/aws/s2n-quic/blob/c221530beb37addf81c7ed58461a945750a1b251/.github/workflows/ci.yml#L613), which overrides the working directory, and enables the `--tests` option of `cargo kani`.
 
 ```yaml
 on:


### PR DESCRIPTION

*Description of changes:* It was pointed out https://github.com/model-checking/kani-verifier-blog/pull/25#discussion_r1052603212 that using a fixed hash rather than a relative reference to main in the s2n-quic example would prevent bit-rot.  Making that change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
